### PR TITLE
:bug: manually bump npm version to 3.18.0-3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@traptitech/traq",
-  "version": "3.18.0-2",
+  "version": "3.18.0-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@traptitech/traq",
-      "version": "3.18.0-2",
+      "version": "3.18.0-3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traptitech/traq",
-  "version": "3.18.0-2",
+  "version": "3.18.0-3",
   "description": "A client library for the traQ API.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
npmでは既に3.18.0-3が上がっていたのに対しpackage.jsonが3.18.0-2のまま(通常は自動更新されるはず)だったので手動でバージョンを上げた