### PR TITLE
use oidc for `npm publish`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
           node-version-file: "package.json"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+
+      # TODO: temporary workaround
+      # Trusted publishing requires npm CLI version 11.5.1 or later.
+      # see: https://docs.npmjs.com/trusted-publishers
+      - name: update npm
+        run: npm install -g npm@latest
+
       - name: npm ci
         run: npm ci
       - name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
         run: npm run build
       - name: Check diff
         run: |
-          OLD_SHASUM=`npm view | grep -oP "(?<=^\.shasum: ).+(?=$)" | sed "s/$(echo -e '\e')\[[0-9][0-9]m//g"`
-          NEW_SHASUM=`npm pack --dry-run 2>&1 >/dev/null | grep -oP "(?<=shasum: ).+(?=$)" | sed "s/^ *//"`
+          OLD_SHASUM=`npm view --json | jq -r '.dist.shasum'`
+          NEW_SHASUM=`npm pack --dry-run --json | jq -r '.[0].shasum'`
 
           echo "OLD: ${OLD_SHASUM}"
           echo "NEW: ${NEW_SHASUM}"
@@ -42,10 +42,10 @@ jobs:
       - name: Set version name
         if: env.HAS_DIFF == 'true'
         run: |
-          TRAQ_VERSION=$(curl -sS https://api.github.com/repos/traPtitech/traQ/tags | jq '.[0].name' | sed -n s/[\"v]//pg)
+          TRAQ_VERSION=$(curl -sS https://api.github.com/repos/traPtitech/traQ/tags | jq -r '.[0].name' | sed -n 's/v//pg')
           echo "TRAQ ${TRAQ_VERSION}"
 
-          VERSION=$(cat ./package.json | jq .version | sed -n s/\"//pg | sed -n s/-/./p)
+          VERSION=$(cat ./package.json | jq -r .version | sed -n 's/-/./p')
           echo "PACKAGE ${VERSION}"
           VERSION_ARR=($(echo $VERSION | tr -s '.' ' '))
           VERSION_SHORT=${VERSION_ARR[0]}.${VERSION_ARR[1]}.${VERSION_ARR[2]}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: checkout
         uses: actions/checkout@v5
@@ -70,5 +71,4 @@ jobs:
           git push --tags
           npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NEW_VERSION: ${{ env.NEW_VERSION }}


### PR DESCRIPTION
as titled
merge 前に、こちら↓ の手順を npm 管理画面側からやっておく必要があります
https://docs.npmjs.com/trusted-publishers#for-github-actions

ついでに検証時に `grep` の `-P` が mac 環境で使えなくて落ちていたので、それも json 出力を使って記述を簡略化しました